### PR TITLE
feat(analytics): split author/project window download changes by asset type

### DIFF
--- a/scripts/lib/analytics-core.ts
+++ b/scripts/lib/analytics-core.ts
@@ -97,6 +97,12 @@ interface ProjectWindowRow {
   adjusted_baseline_total: number;
   latest_snapshot: string;
   baseline_snapshot: string;
+  // Per-asset-type splits of the window movement. Appended last so existing
+  // positional consumers keep working.
+  map_download_change: number;
+  adjusted_map_download_change: number;
+  mod_download_change: number;
+  adjusted_mod_download_change: number;
 }
 
 interface ProjectAllTimeRow {
@@ -162,6 +168,12 @@ interface AuthorWindowRow {
   adjusted_baseline_total: number;
   latest_snapshot: string;
   baseline_snapshot: string;
+  // Per-asset-type splits of the window movement. Appended last so existing
+  // positional consumers keep working.
+  map_download_change: number;
+  adjusted_map_download_change: number;
+  mod_download_change: number;
+  adjusted_mod_download_change: number;
 }
 
 const DEFAULT_TOP_LISTINGS: number | null = null;
@@ -527,6 +539,10 @@ export function runGenerateAnalyticsCli(
         adjusted_baseline_total: 0,
         latest_snapshot: latest.file,
         baseline_snapshot: baseline.file,
+        map_download_change: 0,
+        adjusted_map_download_change: 0,
+        mod_download_change: 0,
+        adjusted_mod_download_change: 0,
       };
       const meta = listingMeta.get(key) ?? {
         name: "",
@@ -551,6 +567,13 @@ export function runGenerateAnalyticsCli(
       existing.adjusted_baseline_total += baselineAdjustedTotal;
       existing.download_change += currentTotal - baselineTotal;
       existing.adjusted_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      if (key.startsWith("maps:")) {
+        existing.map_download_change += currentTotal - baselineTotal;
+        existing.adjusted_map_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      } else {
+        existing.mod_download_change += currentTotal - baselineTotal;
+        existing.adjusted_mod_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      }
       projectStats.set(listingProject.project_key, existing);
     }
 
@@ -718,12 +741,24 @@ export function runGenerateAnalyticsCli(
         adjusted_baseline_total: 0,
         latest_snapshot: latest.file,
         baseline_snapshot: baseline.file,
+        map_download_change: 0,
+        adjusted_map_download_change: 0,
+        mod_download_change: 0,
+        adjusted_mod_download_change: 0,
       };
       existing.asset_count += 1;
       if (entry.listingType === "maps") existing.map_count += 1;
       if (entry.listingType === "mods") existing.mod_count += 1;
       existing.download_change += currentTotal - baselineTotal;
       existing.adjusted_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      if (entry.listingType === "maps") {
+        existing.map_download_change += currentTotal - baselineTotal;
+        existing.adjusted_map_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      }
+      if (entry.listingType === "mods") {
+        existing.mod_download_change += currentTotal - baselineTotal;
+        existing.adjusted_mod_download_change += currentAdjustedTotal - baselineAdjustedTotal;
+      }
       existing.current_total += currentTotal;
       existing.adjusted_current_total += currentAdjustedTotal;
       existing.baseline_total += baselineTotal;
@@ -866,6 +901,10 @@ export function runGenerateAnalyticsCli(
     "adjusted_baseline_total",
     "latest_snapshot",
     "baseline_snapshot",
+    "map_download_change",
+    "adjusted_map_download_change",
+    "mod_download_change",
+    "adjusted_mod_download_change",
   ] as const;
   const authorWindowColumns = [
     "rank",
@@ -883,6 +922,10 @@ export function runGenerateAnalyticsCli(
     "adjusted_baseline_total",
     "latest_snapshot",
     "baseline_snapshot",
+    "map_download_change",
+    "adjusted_map_download_change",
+    "mod_download_change",
+    "adjusted_mod_download_change",
   ] as const;
 
   for (const days of WINDOWS) {

--- a/scripts/tests/analytics-core.unit.test.ts
+++ b/scripts/tests/analytics-core.unit.test.ts
@@ -645,3 +645,93 @@ test("runGenerateAnalyticsCli defaults to full listing and author outputs and st
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+test("runGenerateAnalyticsCli splits author and project window download changes by asset type", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-window-type-split-"));
+  mkdirSync(join(repoRoot, "history"), { recursive: true });
+  mkdirSync(join(repoRoot, "maps", "sample-map"), { recursive: true });
+  mkdirSync(join(repoRoot, "mods", "sample-mod"), { recursive: true });
+
+  try {
+    writeJson(join(repoRoot, "maps", "index.json"), {
+      schema_version: 1,
+      maps: ["sample-map"],
+    });
+    // Both listings share one author and one source repo, so the author row
+    // and the project row each aggregate a map AND a mod.
+    writeJson(join(repoRoot, "maps", "sample-map", "manifest.json"), {
+      schema_version: 1,
+      id: "sample-map",
+      name: "Sample Map",
+      author: "mapmaker",
+      github_id: 1,
+      source: "https://github.com/example/shared-project",
+      city_code: "ABC",
+      country: "US",
+      population: 0,
+      population_count: 0,
+      points_count: 0,
+    });
+    writeJson(join(repoRoot, "mods", "sample-mod", "manifest.json"), {
+      schema_version: 1,
+      id: "sample-mod",
+      name: "Sample Mod",
+      author: "mapmaker",
+      github_id: 1,
+      source: "https://github.com/example/shared-project",
+    });
+    writeJson(join(repoRoot, "history", "snapshot_2026_03_30.json"), {
+      schema_version: 2,
+      snapshot_date: "2026_03_30",
+      generated_at: "2026-03-30T00:00:00.000Z",
+      maps: { downloads: { "sample-map": { "1.0.0": 10 } } },
+      mods: { downloads: { "sample-mod": { "1.0.0": 5 } } },
+    });
+    writeJson(join(repoRoot, "history", "snapshot_2026_03_31.json"), {
+      schema_version: 2,
+      snapshot_date: "2026_03_31",
+      generated_at: "2026-03-31T00:00:00.000Z",
+      maps: { downloads: { "sample-map": { "1.0.0": 13 } } },
+      mods: { downloads: { "sample-mod": { "1.0.0": 7 } } },
+    });
+
+    runGenerateAnalyticsCli([], repoRoot);
+
+    const readRow = (fileName: string, matchColumn: string, matchValue: string) => {
+      const lines = readFileSync(join(repoRoot, "analytics", fileName), "utf-8")
+        .trim()
+        .split(/\r?\n/);
+      const headers = lines[0]!.split(",");
+      const row = lines
+        .slice(1)
+        .map((line) => line.split(","))
+        .find((values) => values[headers.indexOf(matchColumn)] === matchValue);
+      assert.ok(row, `row with ${matchColumn}=${matchValue} in ${fileName}`);
+      return (column: string) => {
+        const index = headers.indexOf(column);
+        assert.notEqual(index, -1, `column ${column} in ${fileName}`);
+        return row[index];
+      };
+    };
+
+    const authorRow = readRow("authors_last_1d.csv", "author", "mapmaker");
+    assert.equal(authorRow("download_change"), "5");
+    assert.equal(authorRow("map_download_change"), "3");
+    assert.equal(authorRow("mod_download_change"), "2");
+    assert.equal(authorRow("adjusted_map_download_change"), "3");
+    assert.equal(authorRow("adjusted_mod_download_change"), "2");
+
+    const projectRow = readRow(
+      "projects_most_popular_last_1d.csv",
+      "project_key",
+      "example/shared-project",
+    );
+    assert.equal(projectRow("download_change"), "5");
+    assert.equal(projectRow("map_download_change"), "3");
+    assert.equal(projectRow("mod_download_change"), "2");
+    assert.equal(projectRow("adjusted_map_download_change"), "3");
+    assert.equal(projectRow("adjusted_mod_download_change"), "2");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/analytics-credits.unit.test.ts
+++ b/scripts/tests/analytics-credits.unit.test.ts
@@ -145,9 +145,9 @@ test("analytics splits a listing's credit at the caretaker window (porto invaria
     assert.equal(
       readAnalyticsCsv(repoRoot, "authors_last_1d.csv"),
       [
-        "rank,author,author_alias,attribution_link,asset_count,map_count,mod_count,download_change,adjusted_download_change,current_total,adjusted_current_total,baseline_total,adjusted_baseline_total,latest_snapshot,baseline_snapshot",
-        "1,capitao,Miguel Sousa,https://github.com/capitao,1,1,0,5,5,25,25,20,20,snapshot_2026_07_31.json,snapshot_2026_07_30.json",
-        "2,bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,2,2,30,30,28,28,snapshot_2026_07_31.json,snapshot_2026_07_30.json",
+        "rank,author,author_alias,attribution_link,asset_count,map_count,mod_count,download_change,adjusted_download_change,current_total,adjusted_current_total,baseline_total,adjusted_baseline_total,latest_snapshot,baseline_snapshot,map_download_change,adjusted_map_download_change,mod_download_change,adjusted_mod_download_change",
+        "1,capitao,Miguel Sousa,https://github.com/capitao,1,1,0,5,5,25,25,20,20,snapshot_2026_07_31.json,snapshot_2026_07_30.json,5,5,0,0",
+        "2,bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,2,2,30,30,28,28,snapshot_2026_07_31.json,snapshot_2026_07_30.json,2,2,0,0",
         "",
       ].join("\n"),
     );


### PR DESCRIPTION
Appends per-asset-type download-change columns — `map_download_change`, `adjusted_map_download_change`, `mod_download_change`, `adjusted_mod_download_change` — to the per-window analytics CSVs:

- `analytics/authors_last_{1,3,7,14,30}d.csv`
- `analytics/projects_most_popular_last_{1,3,7,14,30}d.csv`

This backs the upcoming website change that adds period + asset-type scoping to the Registry Analytics **Authors** and **Projects** tabs: the site needs adjusted window downloads per type to scope the rankings tables (e.g. hide mod-only authors when Maps is selected, and show only the selected type's downloads).

Columns are appended after `baseline_snapshot` so existing positional consumers keep working (same convention as `caretaken_asset_count`). The splits sum exactly to the existing totals: author windows split on the credit entry's listing type, project windows on the listing key's type prefix.

Tests: new unit test covering both CSVs with a mixed map+mod author/project fixture; updated the exact-CSV expectation in `analytics-credits.unit.test.ts`. Full scripts suite passes (478/478).

🤖 Generated with [Claude Code](https://claude.com/claude-code)