### PR TITLE
docs: record the 2026-06-30 hourly-schedule reliability cutoff

### DIFF
--- a/KNOWN_INCIDENTS.md
+++ b/KNOWN_INCIDENTS.md
@@ -389,6 +389,31 @@ restore, the next run re-inspects and the cycle repeats.
 
 ---
 
+## 2026-03-14 → 2026-06-29 — GitHub cron throttling left hourly download runs sparse (fixed by Cloudflare Worker scheduler)
+
+**What happened:** `regenerate-downloads-hourly.yml` relied on GitHub Actions'
+native `schedule` trigger, which GitHub throttles under load: only ~6–10 of
+the 24 hourly runs actually fired per day (e.g. 2026-06-25 saw commits in just
+8 distinct hours). `downloads.json` still converged — every run reads the live
+release counters — but sub-daily movement collapsed into whichever hours
+happened to run.
+
+**Fix:** the Cloudflare Worker scheduler (`workers/scheduler`, deployed
+2026-06-29 firing on the hour; retuned 2026-07-07 to fire twice hourly with
+top-of-hour gating) now dispatches the scheduled workflows directly; the GH
+`schedule` triggers remain only as a late, idempotent fallback. From
+**2026-06-30** every UTC hour has a committed hourly run.
+
+**Residual effect:** git history holds at most ~6–10 counter snapshots per day
+before 2026-06-30, so any backfill of the hourly download series
+(`analytics/hourly/downloads.csv`) from committed `downloads.json` states is
+faithful at hour grain only from **2026-06-30** onward — treat that as the
+hard cutoff when extending the series' retention or backfilling it. Earlier
+movement is recoverable only at the sparse run times (daily grain is
+unaffected).
+
+---
+
 ## 2026-04-07 → 2026-04-10 — App-side download inflation + integrity invalidation (corrected)
 
 Two related problems, corrected as of 2026-04-11.


### PR DESCRIPTION
Records in KNOWN_INCIDENTS.md when hourly download regeneration became reliably hourly, as groundwork for extending the hourly series' retention and backfilling it from git history:

- **2026-03-14 → 2026-06-29:** GitHub Actions cron throttling meant only ~6–10 of 24 hourly runs fired per day (measured: 8 distinct commit hours on 2026-06-25).
- **2026-06-29:** Cloudflare Worker scheduler (`workers/scheduler`) deployed, firing on the hour; retuned 2026-07-07 to twice-hourly with top-of-hour gating.
- **2026-06-30 onward:** every UTC hour has a committed hourly run (measured: 24/24 distinct hours on 2026-07-02).

Consequence: **2026-06-30 is the hard cutoff** for any hour-grain backfill of `analytics/hourly/downloads.csv` from committed `downloads.json` states; earlier movement is only recoverable at the sparse run times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)