### PR TITLE
feat(analytics): first_seen column on asset_versions_by_day.csv

### DIFF
--- a/scripts/lib/analytics-core.ts
+++ b/scripts/lib/analytics-core.ts
@@ -18,6 +18,7 @@ import {
   buildDailyDeltaSnapshotTotals,
   buildListingByDayRows,
   buildListingVersionByDayRows,
+  buildVersionFirstSeenDates,
   buildProjectByDayRows,
   buildSignedDailyDeltaSnapshotTotals,
   toSnapshotDateLabel,
@@ -859,6 +860,7 @@ export function runGenerateAnalyticsCli(
     historyVersionsByListing,
     versionGrain,
     latest.file,
+    buildVersionFirstSeenDates(snapshotDates, listingVersionsBySnapshot),
   );
   const assetsByDayRows = buildAssetsByDayRows(
     snapshotDates,
@@ -1091,6 +1093,7 @@ export function runGenerateAnalyticsCli(
       "version",
       "total_downloads",
       ...snapshotDates,
+      "first_seen",
     ],
     listingVersionByDayRows,
   );

--- a/scripts/lib/analytics/by-day.ts
+++ b/scripts/lib/analytics/by-day.ts
@@ -112,6 +112,29 @@ export function buildListingByDayRows(
   return rows;
 }
 
+// First snapshot date (YYYY_MM_DD) each version key appeared in downloads.json
+// — i.e. the day the version became downloadable (integrity-complete).
+// Keys are `${listingKey}@@${version}`, matching the version-grain series.
+export function buildVersionFirstSeenDates(
+  snapshotDates: string[],
+  listingVersionsBySnapshot: Map<string, { maps: Set<string>; mods: Set<string> }>,
+): Map<string, string> {
+  const firstSeen = new Map<string, string>();
+  for (const snapshotDate of snapshotDates) {
+    const versions = listingVersionsBySnapshot.get(`snapshot_${snapshotDate}.json`);
+    if (!versions) continue;
+    for (const listingType of ["maps", "mods"] as const) {
+      for (const idVersion of versions[listingType]) {
+        const key = `${listingType}:${idVersion}`;
+        if (!firstSeen.has(key)) {
+          firstSeen.set(key, snapshotDate);
+        }
+      }
+    }
+  }
+  return firstSeen;
+}
+
 // Per-(listing, version) daily deltas from the version-grain snapshot series.
 // Version sets come from the full snapshot history, so versions that later
 // disappeared from downloads.json keep their historical rows. Rows are grouped
@@ -123,6 +146,7 @@ export function buildListingVersionByDayRows(
   historyVersionsByListing: Map<ListingKey, Set<string>>,
   versionGrain: VersionGrainSnapshotTotals,
   latestSnapshotFile: string,
+  firstSeenByVersionKey: Map<string, string>,
 ): DailySeriesRow[] {
   const latestMonotonic = versionGrain.monotonicBySnapshot.get(latestSnapshotFile);
   const rows: DailySeriesRow[] = [];
@@ -142,6 +166,9 @@ export function buildListingVersionByDayRows(
         row[snapshotDate] =
           versionGrain.dailyDeltasBySnapshot.get(`snapshot_${snapshotDate}.json`)?.get(versionKey) ?? 0;
       }
+      // Appended last so existing positional consumers keep working. Empty for
+      // versions never present in a snapshot (retired before history began).
+      row.first_seen = firstSeenByVersionKey.get(versionKey) ?? "";
       rows.push(row);
     }
   }

--- a/scripts/tests/analytics-core.unit.test.ts
+++ b/scripts/tests/analytics-core.unit.test.ts
@@ -184,10 +184,10 @@ test("runGenerateAnalyticsCli writes asset_versions_by_day.csv with clamped per-
     assert.equal(
       versionByDayCsv,
       [
-        "listing_type,id,version,total_downloads,2026_03_30,2026_03_31",
-        "map,sample-map,1.0.0,12,10,2",
-        "map,sample-map,1.1.0,4,0,4",
-        "mod,sample-mod,1.0.0,5,5,0",
+        "listing_type,id,version,total_downloads,2026_03_30,2026_03_31,first_seen",
+        "map,sample-map,1.0.0,12,10,2,2026_03_30",
+        "map,sample-map,1.1.0,4,0,4,2026_03_31",
+        "mod,sample-mod,1.0.0,5,5,0,2026_03_30",
         "",
       ].join("\n"),
     );


### PR DESCRIPTION
Appends a `first_seen` column (the version's first snapshot date, `YYYY_MM_DD`) to `analytics/asset_versions_by_day.csv`, derived from the same per-snapshot version sets that already drive `assets_by_day.csv`'s `new_*_versions` counts — so the two series reconcile exactly.

Backs the upcoming website Overview "Releases" section: a New Versions chart (from `assets_by_day.csv`) with a credited "New Versions by Author" pie that needs per-version debut dates to window by period/custom range. Since versions only enter `downloads.json` once integrity-complete, first-seen inherently means "passed integrity."

Column appended last per the positional-consumer convention; empty for versions that never appeared in a snapshot. Full scripts suite passes (480/480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)