### PR TITLE
fix(publish): drop the checkout extraheader so the re-minted push credential applies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -465,6 +465,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
+          # The checkout action persists an Authorization extraheader carrying
+          # the token minted at run start; git applies it to every github.com
+          # request and it overrides the fresh credential embedded in the URL
+          # below (2026-09-09: the re-minted push still failed with "Invalid
+          # username or token" while gh api calls with the same fresh token
+          # succeeded). Drop it so the URL credential is actually used.
+          git config --local --unset-all http.https://github.com/.extraheader || true
           remote="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           # A re-run regenerates this branch from main and force-pushes, which
           # would clobber the data-quality answers the questionnaire flow may


### PR DESCRIPTION
Moscow's post-#10313 run still died at the push — but with a twist that identifies the real culprit: the re-minted token was **valid** (the `gh api` ref-cleanup calls between the two git failures succeeded with it), yet both `git fetch` and `git push` failed with `Invalid username or token`.

Cause: `actions/checkout` persists an `http.https://github.com/.extraheader` Authorization header carrying the token minted at run start. Git applies that header to **every** github.com request, overriding the fresh URL-embedded credential. The analytics publish (#7707) never hit this because it pushes from a fresh `git init` snapshot; publish.yml pushes from the checkout itself.

Fix: `git config --local --unset-all http.https://github.com/.extraheader` before the fetch/push. After merge, one more `revalidate` on #10086 (~80 min) should finally land Moscow's publish PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)