### PR TITLE
deprecate: mfn-rdu + mfn-msy (author-requested)

### DIFF
--- a/maps/grandfathered-downloads.json
+++ b/maps/grandfathered-downloads.json
@@ -102,8 +102,14 @@
   "mfn-madisonwi": {
     "3.0.0": 382
   },
+  "mfn-msy": {
+    "1.0.0": 264
+  },
   "mfn-northwestar": {
     "1.0.0": 176
+  },
+  "mfn-rdu": {
+    "1.0.0": 143
   },
   "montpellier-mediterranee": {
     "v1.0.0": 111

--- a/maps/mfn-msy/manifest.json
+++ b/maps/mfn-msy/manifest.json
@@ -166,5 +166,10 @@
     "weighted_score": 0.87,
     "rubric_version": 1,
     "provenance": "backfill"
+  },
+  "deprecation": {
+    "since": "2026-09-09T05:49:05.073Z",
+    "by_github_id": 19807509,
+    "reason": "Deprecated at the author's request: built before game version 1.4 and no longer compatible; will not be updated."
   }
 }

--- a/maps/mfn-rdu/manifest.json
+++ b/maps/mfn-rdu/manifest.json
@@ -177,5 +177,10 @@
     "weighted_score": 0.87,
     "rubric_version": 1,
     "provenance": "backfill"
+  },
+  "deprecation": {
+    "since": "2026-09-09T05:49:03.155Z",
+    "by_github_id": 19807509,
+    "reason": "Deprecated at the author's request: built before game version 1.4 and no longer compatible; will not be updated."
   }
 }


### PR DESCRIPTION
crumpetime (Muffintime) asked to retire their two remaining pre-1.4 builds — **mfn-rdu** and **mfn-msy** (no buildings-index .bin, incompatible since the 1.4 release). **mfn-lasvegas is deliberately kept** for a future update. Downloads frozen via `deprecate-listing.ts`.

Side effect: these are two of the twelve live metronome list-B members — the loop residual should thin further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)