### PR TITLE
fix(analytics): drop busan-3's phantom +343 hourly row

### DIFF
--- a/analytics/hourly/downloads-2026-09.csv
+++ b/analytics/hourly/downloads-2026-09.csv
@@ -8634,7 +8634,6 @@ bucket_utc,listing_type,id,downloads
 2026-09-09T03:00Z,mod,track-visualizer,1
 2026-09-09T03:00Z,mod,transit-overlay,2
 2026-09-09T04:00Z,map,amba,1
-2026-09-09T04:00Z,map,busan-3,343
 2026-09-09T04:00Z,map,ciudad-de-mexico,1
 2026-09-09T04:00Z,map,greater-chicagoland,1
 2026-09-09T04:00Z,map,shanghai,3


### PR DESCRIPTION
Companion to #10404: the freeze bug's one booking in the append-only hourly shards — `2026-09-09T04:00Z,map,busan-3,343` — removed. Verified it's the only phantom row across all three monthly shards (dantrains/advanced-analytics never booked hourly outliers; their chart artifacts come from the snapshot-derived cache, refreshed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)